### PR TITLE
Updated cmake build scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
       env: TOOLSET=clang++ BUILD_TYPE='Release'
 
 #-----------------------------------------------------------------------------
-# Installation Steps
+# Installation Step
 #-----------------------------------------------------------------------------
 install:
   - cd ../
@@ -77,8 +77,7 @@ install:
 #-----------------------------------------------------------------------------
 script:
   - mkdir build/ && cd build/
-  - echo $CMAKE .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INCLUDE_PATH=$CATCH_DIR -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic $CXX_FLAGS" -DBIT_MATH_COMPILE_UNIT_TESTS=On
-  - $CMAKE .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INCLUDE_PATH=$CATCH_DIR -DCMAKE_CXX_FLAGS="-Wall -Wextra -pedantic $CXX_FLAGS" -DBIT_MATH_COMPILE_UNIT_TESTS=On
+  - export CTEST_OUTPUT_ON_FAILURE=1
+  - $CMAKE .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INCLUDE_PATH=$CATCH_DIR -DBIT_MATH_COMPILE_HEADER_SELF_CONTAINMENT_TESTS=On -DBIT_MATH_COMPILE_UNIT_TESTS=On
   - $CMAKE --build .
-  - ./test/math_test
   - $CMAKE --build . --target test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,17 +4,15 @@ enable_testing()
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 
-include(GitBuildInformation)
 include(MakeVersionHeader)
-include(AddIndependenceCheck)
-include(AddTestExecutable)
+include(AddHeaderSelfContainmentTest)
 
 #-----------------------------------------------------------------------------
 # Project Setup
 #-----------------------------------------------------------------------------
 
-option(BIT_MATH_COMPILE_INDEPENDENCE_TESTS "Include each header independently in a .cpp file to determine header independence" on)
-option(BIT_MATH_COMPILE_UNIT_TESTS "Compile and run the unit tests for this library" on)
+option(BIT_MATH_COMPILE_HEADER_SELF_CONTAINMENT_TESTS "Include each header independently in a .cpp file to determine header self-containment" off)
+option(BIT_MATH_COMPILE_UNIT_TESTS "Compile and run the unit tests for this library" off)
 option(BIT_MATH_GENERATE_DOCUMENTATION "Generates doxygen documentation" off)
 
 option(BIT_MATH_DOUBLE_PRECISION "Use double precision for mathematics." off)
@@ -24,16 +22,12 @@ option(BIT_MATH_INCLUDE_HALF "Includes bit::math::half for IEEE half-precision f
 set(BIT_MATH_TRIG_TABLE_SIZE 1024 CACHE STRING "The size of the trig table to build. This is ignored unless BIT_MATH_CACHED_TRIG is on")
 set(BIT_MATH_INVERSE_TRIG_TABLE_SIZE 4096 CACHE STRING "The size of the inverse trig table to build. This is ignored unless BIT_MATH_CACHED_TRIG is on")
 
-project("bit-math")
+project("BitMemory")
 
 if( CMAKE_BUILD_TYPE STREQUAL "" )
   message(STATUS "CMAKE_BUILD_TYPE not set; defaulting to 'Debug'")
   set(CMAKE_BUILD_TYPE DEBUG)
 endif()
-
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED true)
-
 
 #-----------------------------------------------------------------------------
 # Option Validation
@@ -57,10 +51,17 @@ set(BIT_MATH_VERSION_MAJOR 0 CACHE STRING "major version of bit::math" FORCE)
 set(BIT_MATH_VERSION_MINOR 1 CACHE STRING "minor version of bit::math" FORCE)
 set(BIT_MATH_VERSION_PATCH 62 CACHE STRING "patch version of bit::math" FORCE)
 set(BIT_MATH_VERSION_SUFFIX "a" CACHE STRING "version suffix" FORCE)
-set(BIT_MATH_BUILD_NUMBER "${BIT_MATH_BUILD_NUMBER}" CACHE STRING "build number of bit::math" FORCE)
+
 set(BIT_MATH_VERSION "${BIT_MATH_VERSION_MAJOR}.${BIT_MATH_VERSION_MINOR}.${BIT_MATH_VERSION_PATCH}${BIT_MATH_VERSION_SUFFIX}" CACHE STRING "version of bit::math" FORCE)
 
 message(STATUS "bit::math ${BIT_MATH_VERSION}")
+
+#-----------------------------------------------------------------------------
+# bit::math
+#-----------------------------------------------------------------------------
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED true)
 
 #-----------------------------------------------------------------------------
 # bit::math : Sources
@@ -214,30 +215,32 @@ endif()
 # bit::math : Library
 #-----------------------------------------------------------------------------
 
-add_library(math ${sources} ${headers})
-add_library("bit::math" ALIAS math)
-target_include_directories(math PUBLIC
+add_library(bit_math ${sources} ${headers})
+add_library("bit::math" ALIAS bit_math)
+target_include_directories(bit_math PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
 )
+
 # Add compiler-specific flags
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  target_compile_options(math PUBLIC -Wall -pedantic)
+  target_compile_options(bit_math PUBLIC -Wall -pedantic)
 elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" )
-  target_compile_options(math PUBLIC -Wall -pedantic)
+  target_compile_options(bit_math PUBLIC -Wall -pedantic)
 elseif( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" )
   # TODO: Determine MSVC necessary compiler flags
 endif()
 
 #-----------------------------------------------------------------------------
-# bit::math : Independence Tests
+# bit::math : Header Self-Containment Test
 #-----------------------------------------------------------------------------
 
-if( BIT_MATH_COMPILE_INDEPENDENCE_TESTS )
-  add_independence_check(math_independence ${headers})
+if( BIT_MATH_COMPILE_HEADER_SELF_CONTAINMENT_TESTS )
+  add_header_self_containment_test(bit_math_header_self_containment_test ${headers})
+  add_library(bit::math::header_self_containment_test ALIAS bit_math_header_self_containment_test)
 
-  target_include_directories(math_independence PRIVATE $<TARGET_PROPERTY:math,INCLUDE_DIRECTORIES>)
-  target_compile_options(math_independence PRIVATE $<TARGET_PROPERTY:math,INTERFACE_COMPILE_OPTIONS>)
+  target_include_directories(bit_math_header_self_containment_test PRIVATE $<TARGET_PROPERTY:bit_math,INCLUDE_DIRECTORIES>)
+  target_compile_options(bit_math_header_self_containment_test PRIVATE $<TARGET_PROPERTY:bit_math,INTERFACE_COMPILE_OPTIONS>)
 endif()
 
 #-----------------------------------------------------------------------------
@@ -266,7 +269,7 @@ if( EXISTS "$ENV{BIT_HOME}" )
   set(CMAKE_INSTALL_PREFIX "$ENV{BIT_HOME}")
 endif()
 
-export_library( TARGETS math
+export_library( TARGETS bit_math
                 PACKAGE Math
                 VERSION ${BIT_MATH_VERSION}
                 MAJOR_VERSION ${BIT_MATH_VERSION_MAJOR}

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -6,7 +6,7 @@ find_program(CMAKE_DOXYGEN_PROGRAM doxygen)
 set(CMAKE_FIND_APPBUNDLE ${temp_state})
 
 # Add target for generating doxygen
-add_custom_target("bit-math-doxygen" ALL
+add_custom_target("bit_math_doxygen" ALL
                   COMMAND "${CMAKE_DOXYGEN_PROGRAM}" "Doxyfile"
                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
                   COMMENT "Generating Doxygen documentation for 'bit::math'"

--- a/include/bit/math/detail/matrix.inl
+++ b/include/bit/math/detail/matrix.inl
@@ -5,24 +5,17 @@
 # error "matrix.inl included without first including declaration header matrix.hpp"
 #endif
 
-//----------------------------------------------------------------------------
-// Casts
-//----------------------------------------------------------------------------
-
-template<typename To, typename From>
-inline constexpr To bit::math::casts::matrix_cast(const From& from)
-{
-  return detail::matrix_caster<To,From>::cast(from);
-}
 
 //----------------------------------------------------------------------------
 // matrix2 -> matrixN
 //----------------------------------------------------------------------------
 
+namespace bit { namespace math { namespace detail {
+
 template<typename T, typename U>
-struct bit::math::detail::matrix_caster<bit::math::matrix2<T>, bit::math::matrix2<U>>
+struct matrix_caster<matrix2<T>, matrix2<U>>
 {
-  static constexpr bit::math::matrix2<T> cast( const bit::math::matrix2<U>& rhs )
+  static constexpr matrix2<T> cast( const matrix2<U>& rhs )
     noexcept
   {
     return matrix2<T>(rhs);
@@ -32,9 +25,9 @@ struct bit::math::detail::matrix_caster<bit::math::matrix2<T>, bit::math::matrix
 //----------------------------------------------------------------------------
 
 template<typename T, typename U>
-struct bit::math::detail::matrix_caster<bit::math::matrix3<T>, bit::math::matrix2<U>>
+struct matrix_caster<matrix3<T>, matrix2<U>>
 {
-  static constexpr bit::math::matrix3<T> cast( const bit::math::matrix2<U>& rhs )
+  static constexpr matrix3<T> cast( const matrix2<U>& rhs )
     noexcept
   {
     return matrix3<T>( rhs(0,0), rhs(0,1), T(0),
@@ -46,9 +39,9 @@ struct bit::math::detail::matrix_caster<bit::math::matrix3<T>, bit::math::matrix
 //----------------------------------------------------------------------------
 
 template<typename T, typename U>
-struct bit::math::detail::matrix_caster<bit::math::matrix4<T>, bit::math::matrix2<U>>
+struct matrix_caster<matrix4<T>, matrix2<U>>
 {
-  static constexpr bit::math::matrix4<T> cast( const bit::math::matrix2<U>& rhs )
+  static constexpr matrix4<T> cast( const matrix2<U>& rhs )
     noexcept
   {
     return matrix3<T>( rhs(0,0), rhs(0,1), T(0), T(0),
@@ -63,9 +56,9 @@ struct bit::math::detail::matrix_caster<bit::math::matrix4<T>, bit::math::matrix
 //----------------------------------------------------------------------------
 
 template<typename T, typename U>
-struct bit::math::detail::matrix_caster<bit::math::matrix2<T>, bit::math::matrix3<U>>
+struct matrix_caster<matrix2<T>, matrix3<U>>
 {
-  static constexpr bit::math::matrix2<T> cast( const bit::math::matrix3<U>& rhs )
+  static constexpr matrix2<T> cast( const matrix3<U>& rhs )
     noexcept
   {
     return matrix2<T>( rhs(0,0), rhs(0,1),
@@ -76,9 +69,9 @@ struct bit::math::detail::matrix_caster<bit::math::matrix2<T>, bit::math::matrix
 //----------------------------------------------------------------------------
 
 template<typename T, typename U>
-struct bit::math::detail::matrix_caster<bit::math::matrix3<T>, bit::math::matrix3<U>>
+struct matrix_caster<matrix3<T>, matrix3<U>>
 {
-  static constexpr bit::math::matrix3<T> cast( const bit::math::matrix3<U>& rhs )
+  static constexpr matrix3<T> cast( const matrix3<U>& rhs )
     noexcept
   {
     return matrix3<T>(rhs);
@@ -88,9 +81,9 @@ struct bit::math::detail::matrix_caster<bit::math::matrix3<T>, bit::math::matrix
 //----------------------------------------------------------------------------
 
 template<typename T, typename U>
-struct bit::math::detail::matrix_caster<bit::math::matrix4<T>, bit::math::matrix3<U>>
+struct matrix_caster<matrix4<T>, matrix3<U>>
 {
-  static constexpr bit::math::matrix4<T> cast( const bit::math::matrix3<U>& rhs )
+  static constexpr matrix4<T> cast( const matrix3<U>& rhs )
     noexcept
   {
     return matrix4<T>( rhs(0,0), rhs(0,1), T(0), rhs(0,2),
@@ -105,9 +98,9 @@ struct bit::math::detail::matrix_caster<bit::math::matrix4<T>, bit::math::matrix
 //----------------------------------------------------------------------------
 
 template<typename T, typename U>
-struct bit::math::detail::matrix_caster<bit::math::matrix2<T>, bit::math::matrix4<U>>
+struct matrix_caster<matrix2<T>, matrix4<U>>
 {
-  static constexpr bit::math::matrix2<T> cast( const bit::math::matrix4<U>& rhs )
+  static constexpr matrix2<T> cast( const matrix4<U>& rhs )
     noexcept
   {
     return matrix2<T>( rhs(0,0), rhs(0,1),
@@ -118,9 +111,9 @@ struct bit::math::detail::matrix_caster<bit::math::matrix2<T>, bit::math::matrix
 //----------------------------------------------------------------------------
 
 template<typename T, typename U>
-struct bit::math::detail::matrix_caster<bit::math::matrix3<T>, bit::math::matrix4<U>>
+struct matrix_caster<matrix3<T>, matrix4<U>>
 {
-  static constexpr bit::math::matrix3<T> cast( const bit::math::matrix4<U>& rhs )
+  static constexpr matrix3<T> cast( const matrix4<U>& rhs )
     noexcept
   {
     return matrix3<T>( rhs(0,0), rhs(0,1), rhs(0,3),
@@ -132,13 +125,25 @@ struct bit::math::detail::matrix_caster<bit::math::matrix3<T>, bit::math::matrix
 //----------------------------------------------------------------------------
 
 template<typename T, typename U>
-struct bit::math::detail::matrix_caster<bit::math::matrix4<T>, bit::math::matrix4<U>>
+struct matrix_caster<matrix4<T>, matrix4<U>>
 {
-  static constexpr bit::math::matrix4<T> cast( const bit::math::matrix4<U>& rhs )
+  static constexpr matrix4<T> cast( const matrix4<U>& rhs )
     noexcept
   {
     return matrix4<T>(rhs);
   }
 };
+
+} } } // namespace bit::math::detail
+
+//----------------------------------------------------------------------------
+// Casts
+//----------------------------------------------------------------------------
+
+template<typename To, typename From>
+inline constexpr To bit::math::casts::matrix_cast(const From& from)
+{
+  return detail::matrix_caster<To,From>::cast(from);
+}
 
 #endif /* BIT_MATH_DETAIL_MATRIX_INL */

--- a/include/bit/math/detail/vector.inl
+++ b/include/bit/math/detail/vector.inl
@@ -9,10 +9,12 @@
 // Detail: Vector Casting
 //----------------------------------------------------------------------------
 
+namespace bit { namespace math { namespace detail {
+
 template<typename T, typename U>
-struct bit::math::detail::vector_caster<bit::math::vector2<T>,bit::math::vector2<U>>
+struct vector_caster<vector2<T>,vector2<U>>
 {
-  static constexpr bit::math::vector2<T> cast( const bit::math::vector2<U>& from )
+  static constexpr vector2<T> cast( const vector2<U>& from )
     noexcept
   {
     return vector2<T>( from );
@@ -20,9 +22,9 @@ struct bit::math::detail::vector_caster<bit::math::vector2<T>,bit::math::vector2
 };
 
 template<typename T, typename U>
-struct bit::math::detail::vector_caster<bit::math::vector3<T>,bit::math::vector2<U>>
+struct vector_caster<vector3<T>,vector2<U>>
 {
-  static constexpr bit::math::vector3<T> cast( const bit::math::vector2<U>& from )
+  static constexpr vector3<T> cast( const vector2<U>& from )
     noexcept
   {
     return vector3<T>( from.x(), from.y(), T(0) );
@@ -30,9 +32,9 @@ struct bit::math::detail::vector_caster<bit::math::vector3<T>,bit::math::vector2
 };
 
 template<typename T, typename U>
-struct bit::math::detail::vector_caster<bit::math::vector4<T>,bit::math::vector2<U>>
+struct vector_caster<vector4<T>,vector2<U>>
 {
-  static constexpr bit::math::vector4<T> cast( const bit::math::vector2<U>& from )
+  static constexpr vector4<T> cast( const vector2<U>& from )
     noexcept
   {
     return vector4<T>( from.x(), from.y(), T(0), T(0) );
@@ -42,9 +44,9 @@ struct bit::math::detail::vector_caster<bit::math::vector4<T>,bit::math::vector2
 //----------------------------------------------------------------------------
 
 template<typename T, typename U>
-struct bit::math::detail::vector_caster<bit::math::vector2<T>,bit::math::vector3<U>>
+struct vector_caster<vector2<T>,vector3<U>>
 {
-  static constexpr bit::math::vector2<T> cast( const bit::math::vector3<U>& from )
+  static constexpr vector2<T> cast( const vector3<U>& from )
     noexcept
   {
     return vector2<T>( from.x(), from.y() );
@@ -52,9 +54,9 @@ struct bit::math::detail::vector_caster<bit::math::vector2<T>,bit::math::vector3
 };
 
 template<typename T, typename U>
-struct bit::math::detail::vector_caster<bit::math::vector3<T>,bit::math::vector3<U>>
+struct vector_caster<vector3<T>,vector3<U>>
 {
-  static constexpr bit::math::vector3<T> cast( const bit::math::vector3<U>& from )
+  static constexpr vector3<T> cast( const vector3<U>& from )
     noexcept
   {
     return vector3<T>( from );
@@ -62,9 +64,9 @@ struct bit::math::detail::vector_caster<bit::math::vector3<T>,bit::math::vector3
 };
 
 template<typename T, typename U>
-struct bit::math::detail::vector_caster<bit::math::vector4<T>,bit::math::vector3<U>>
+struct vector_caster<vector4<T>,vector3<U>>
 {
-  static constexpr bit::math::vector4<T> cast( const bit::math::vector3<U>& from )
+  static constexpr vector4<T> cast( const vector3<U>& from )
     noexcept
   {
     return vector4<T>( from.x(), from.y(), from.z(), T(0) );
@@ -74,9 +76,9 @@ struct bit::math::detail::vector_caster<bit::math::vector4<T>,bit::math::vector3
 //----------------------------------------------------------------------------
 
 template<typename T, typename U>
-struct bit::math::detail::vector_caster<bit::math::vector2<T>,bit::math::vector4<U>>
+struct vector_caster<vector2<T>,vector4<U>>
 {
-  static constexpr bit::math::vector2<T> cast( const bit::math::vector4<U>& from )
+  static constexpr vector2<T> cast( const vector4<U>& from )
     noexcept
   {
     return vector2<T>( from.x(), from.y() );
@@ -84,9 +86,9 @@ struct bit::math::detail::vector_caster<bit::math::vector2<T>,bit::math::vector4
 };
 
 template<typename T, typename U>
-struct bit::math::detail::vector_caster<bit::math::vector3<T>,bit::math::vector4<U>>
+struct vector_caster<vector3<T>,vector4<U>>
 {
-  static constexpr bit::math::vector3<T> cast( const bit::math::vector4<U>& from )
+  static constexpr vector3<T> cast( const vector4<U>& from )
     noexcept
   {
     return vector3<T>( from.x(), from.y(), from.z() );
@@ -94,14 +96,16 @@ struct bit::math::detail::vector_caster<bit::math::vector3<T>,bit::math::vector4
 };
 
 template<typename T, typename U>
-struct bit::math::detail::vector_caster<bit::math::vector4<T>,bit::math::vector4<U>>
+struct vector_caster<vector4<T>,vector4<U>>
 {
-  static constexpr bit::math::vector4<T> cast( const bit::math::vector4<U>& from )
+  static constexpr vector4<T> cast( const vector4<U>& from )
     noexcept
   {
     return vector4<T>( from );
   }
 };
+
+} } } // namespace bit::math::detail
 
 //----------------------------------------------------------------------------
 // Vector Casting

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,20 +11,20 @@ set(source_files
   bit/math/clamped.test.cpp
 )
 
-add_executable(math_test ${source_files})
+add_executable(bit_math_test ${source_files})
 
-target_link_libraries(math_test PRIVATE "bit::math" "philsquared::Catch")
+target_link_libraries(bit_math_test PRIVATE "bit::math" "philsquared::Catch")
 
 #-----------------------------------------------------------------------------
 # Testing
 #-----------------------------------------------------------------------------
 
-add_test( NAME "math_test_default"
+add_test( NAME "bit_math_test_default"
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-          COMMAND "$<TARGET_FILE:math_test>" )
+          COMMAND "$<TARGET_FILE:bit_math_test>" )
 
 #-----------------------------------------------------------------------------
 
-add_test( NAME "math_test_all"
+add_test( NAME "bit_math_test_all"
           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-          COMMAND "$<TARGET_FILE:math_test>" "*" )
+          COMMAND "$<TARGET_FILE:bit_math_test>" "*" )


### PR DESCRIPTION
- Updates the name of independence check -> header self containment tests
- Updates target name from 'math' -> 'bit_math'
- Disables unit tests and self-containment tests by default
- Updates CI scripts to make use of these changes